### PR TITLE
[Refactor] 블로그 등록/수정/삭제/UI 로직 점검 #68

### DIFF
--- a/TILApp.xcodeproj/project.pbxproj
+++ b/TILApp.xcodeproj/project.pbxproj
@@ -53,6 +53,8 @@
 		9BE049C22AED60EE00A47CFC /* UserTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BE049C12AED60EE00A47CFC /* UserTableViewCell.swift */; };
 		AB75EDE82AEF9CBB00BC1BC9 /* XMLCoder in Frameworks */ = {isa = PBXBuildFile; productRef = AB75EDE72AEF9CBB00BC1BC9 /* XMLCoder */; };
 		AB8F2A1A2AEF9B260022D3E4 /* FSCalendar in Frameworks */ = {isa = PBXBuildFile; productRef = AB8F2A192AEF9B260022D3E4 /* FSCalendar */; };
+		D20DC9E42AF206D8001F83D0 /* KeywordInputViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D20DC9E32AF206D8001F83D0 /* KeywordInputViewModel.swift */; };
+		D20DC9E62AF2098F001F83D0 /* KeywordInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = D20DC9E52AF2098F001F83D0 /* KeywordInput.swift */; };
 		D24BB9912AE106F000ED7028 /* BlogListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D24BB9902AE106F000ED7028 /* BlogListViewController.swift */; };
 		D24BB9932AE107F800ED7028 /* BlogListTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D24BB9922AE107F800ED7028 /* BlogListTableViewCell.swift */; };
 		D24BB9952AE1104400ED7028 /* BlogEditViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D24BB9942AE1104400ED7028 /* BlogEditViewController.swift */; };
@@ -124,6 +126,8 @@
 		9BE049BF2AED229600A47CFC /* UserProfileViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserProfileViewController.swift; sourceTree = "<group>"; };
 		9BE049C12AED60EE00A47CFC /* UserTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserTableViewCell.swift; sourceTree = "<group>"; };
 		D20AD8D02ADC5ECA00CDEB2C /* TILApp.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = TILApp.entitlements; sourceTree = "<group>"; };
+		D20DC9E32AF206D8001F83D0 /* KeywordInputViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeywordInputViewModel.swift; sourceTree = "<group>"; };
+		D20DC9E52AF2098F001F83D0 /* KeywordInput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeywordInput.swift; sourceTree = "<group>"; };
 		D24BB9902AE106F000ED7028 /* BlogListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlogListViewController.swift; sourceTree = "<group>"; };
 		D24BB9922AE107F800ED7028 /* BlogListTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlogListTableViewCell.swift; sourceTree = "<group>"; };
 		D24BB9942AE1104400ED7028 /* BlogEditViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlogEditViewController.swift; sourceTree = "<group>"; };
@@ -226,6 +230,7 @@
 				33A4E8232AECB4C700E3F55E /* UserViewModel.swift */,
 				33A4E81B2AEBB14800E3F55E /* BlogViewModel.swift */,
 				33A4E8252AECB57000E3F55E /* PostViewModel.swift */,
+				D20DC9E32AF206D8001F83D0 /* KeywordInputViewModel.swift */,
 				33A4E83D2AF0ECD700E3F55E /* CommunityViewModel.swift */,
 			);
 			path = ViewModels;
@@ -239,6 +244,7 @@
 				3334E1C82AD911ED00D853D7 /* Blog.swift */,
 				3334E1CC2AD9126400D853D7 /* Post.swift */,
 				33A4E82F2AEF740600E3F55E /* Community.swift */,
+				D20DC9E52AF2098F001F83D0 /* KeywordInput.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -515,6 +521,7 @@
 				33A4E81C2AEBB14800E3F55E /* BlogViewModel.swift in Sources */,
 				D2CDB7152AEB69DB00BFD8C2 /* TestComponentsViewController.swift in Sources */,
 				D2A4D1FD2AE60EDC00B510A3 /* CommunityTableViewCell.swift in Sources */,
+				D20DC9E42AF206D8001F83D0 /* KeywordInputViewModel.swift in Sources */,
 				3334E1C92AD911ED00D853D7 /* Blog.swift in Sources */,
 				D2CDB6F92AEB671800BFD8C2 /* CustomFollowButton.swift in Sources */,
 				D2A4D1FB2AE5DF9000B510A3 /* FollowListTableViewCell.swift in Sources */,
@@ -540,6 +547,7 @@
 				D2CDB7032AEB680300BFD8C2 /* CustomTextFieldViewWithValidation.swift in Sources */,
 				33A4E8262AECB57000E3F55E /* PostViewModel.swift in Sources */,
 				D29659F02AE7EEEB000C28A6 /* TagCollectionViewFlowLayout.swift in Sources */,
+				D20DC9E62AF2098F001F83D0 /* KeywordInput.swift in Sources */,
 				33A4E8302AEF740600E3F55E /* Community.swift in Sources */,
 				33A4E8282AECBDE300E3F55E /* SeeMorePresentationController.swift in Sources */,
 				33A4E8242AECB4C700E3F55E /* UserViewModel.swift in Sources */,

--- a/TILApp/Models/Blog.swift
+++ b/TILApp/Models/Blog.swift
@@ -27,22 +27,3 @@ struct UpdateBlogInput: Codable {
     let name: String?
     let keywords: [KeywordInput]?
 }
-
-struct KeywordInput: Codable, Equatable {
-    var keyword: String
-    var tags: [String]
-
-    init(keyword: String, tags: [String]) {
-        self.keyword = keyword
-        self.tags = tags
-    }
-
-    init(from keyword: Keyword) {
-        self.keyword = keyword.keyword
-        self.tags = keyword.tags
-    }
-    
-    static func == (lhs: KeywordInput, rhs: KeywordInput) -> Bool {
-        return lhs.keyword == rhs.keyword && lhs.tags == rhs.tags
-    }
-}

--- a/TILApp/Models/KeywordInput.swift
+++ b/TILApp/Models/KeywordInput.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+struct KeywordInput: Codable, Equatable {
+    var keyword: String
+    var tags: [String]
+
+    init(keyword: String, tags: [String]) {
+        self.keyword = keyword
+        self.tags = tags
+    }
+
+    init(from keyword: Keyword) {
+        self.keyword = keyword.keyword
+        self.tags = keyword.tags
+    }
+    
+    static func == (lhs: KeywordInput, rhs: KeywordInput) -> Bool {
+        return lhs.keyword == rhs.keyword && lhs.tags == rhs.tags
+    }
+}

--- a/TILApp/Utilities/converter.swift
+++ b/TILApp/Utilities/converter.swift
@@ -14,3 +14,21 @@ func toDictionary(from object: Any) -> [String: Any] {
     }
     return result
 }
+
+func convertToRssUrl(from blogUrl: String) -> String? {
+    var separateUrl = blogUrl.components(separatedBy: "https://").joined()
+    separateUrl = separateUrl.components(separatedBy: "/rss").joined()
+    separateUrl = separateUrl.components(separatedBy: "/feed").joined()
+    let splitUrl = separateUrl.split(separator: "/")
+
+    if splitUrl[0].contains("tistory.com") {
+        return "https://" + splitUrl[0] + "/rss"
+    } else if splitUrl[0].contains("naver.com") {
+        return "https://" + "rss." + "blog.naver.com/" + splitUrl[1]
+    } else if splitUrl[0].contains("velog.io") {
+        return "https://" + "v2." + "velog.io/rss/" + splitUrl[1]
+    } else if splitUrl[0].contains("medium.com") {
+        return "https://" + "medium.com/feed/" + splitUrl[1]
+    }
+    return nil
+}

--- a/TILApp/ViewModels/BlogViewModel.swift
+++ b/TILApp/ViewModels/BlogViewModel.swift
@@ -59,12 +59,8 @@ final class BlogViewModel {
     func setMainBlog(_ id: Int, onSuccess: (() -> Void)? = nil, onError: ((Error) -> Void)? = nil) {
         APIService.shared.request(.setMainBlog(id)) { [weak self] _ in
             guard let self = self else { return }
-            load { [weak self] _ in
-                guard let self else { return }
-                onSuccess?()
-            } onError: { error in
-                print(error)
-            }
+            updateMainBlog(id)
+            onSuccess?()
         } onError: { error in
             onError?(error)
         }
@@ -77,8 +73,39 @@ final class BlogViewModel {
     func hasBlogName(_ blogNameToCheck: String) -> Bool {
         return blogs.contains { $0.name == blogNameToCheck }
     }
-    
+
     func hasBlogURL(_ url: String) -> Bool {
         return blogs.contains { $0.url == url }
+    }
+
+    func updateMainBlog(_ id: Int) {
+        if let index = blogs.firstIndex(where: { $0.main }) {
+            let oldBlog = blogs[index]
+            let newBlog: Blog = .init(
+                id: oldBlog.id,
+                name: oldBlog.name,
+                url: oldBlog.url,
+                rss: oldBlog.rss,
+                main: false,
+                keywords: oldBlog.keywords,
+                lastPublishedAt: oldBlog.lastPublishedAt,
+                createdAt: oldBlog.createdAt
+            )
+            blogs[index] = newBlog
+        }
+        if let index = blogs.firstIndex(where: { $0.id == id }) {
+            let oldBlog = blogs[index]
+            let newBlog: Blog = .init(
+                id: oldBlog.id,
+                name: oldBlog.name,
+                url: oldBlog.url,
+                rss: oldBlog.rss,
+                main: true,
+                keywords: oldBlog.keywords,
+                lastPublishedAt: oldBlog.lastPublishedAt,
+                createdAt: oldBlog.createdAt
+            )
+            blogs[index] = newBlog
+        }
     }
 }

--- a/TILApp/ViewModels/BlogViewModel.swift
+++ b/TILApp/ViewModels/BlogViewModel.swift
@@ -77,4 +77,8 @@ final class BlogViewModel {
     func hasBlogName(_ blogNameToCheck: String) -> Bool {
         return blogs.contains { $0.name == blogNameToCheck }
     }
+    
+    func hasBlogURL(_ url: String) -> Bool {
+        return blogs.contains { $0.url == url }
+    }
 }

--- a/TILApp/ViewModels/BlogViewModel.swift
+++ b/TILApp/ViewModels/BlogViewModel.swift
@@ -55,13 +55,16 @@ final class BlogViewModel {
             onError?(error)
         }
     }
-    
-    // TODO: 결과 받아와서 blogs에 적용하기
+
     func setMainBlog(_ id: Int, onSuccess: (() -> Void)? = nil, onError: ((Error) -> Void)? = nil) {
         APIService.shared.request(.setMainBlog(id)) { [weak self] _ in
-            guard self != nil else { return }
-            
-            onSuccess?()
+            guard let self = self else { return }
+            load { [weak self] _ in
+                guard let self else { return }
+                onSuccess?()
+            } onError: { error in
+                print(error)
+            }
         } onError: { error in
             onError?(error)
         }
@@ -70,13 +73,8 @@ final class BlogViewModel {
     func getBlog(blogId: Int) -> Blog {
         return blogs.first { $0.id == blogId }!
     }
-    
-    func deleteBlog(blogId: Int) {
-        blogs.removeAll(where: { $0.id == blogId })
-    }
-    
+
     func hasBlogName(_ blogNameToCheck: String) -> Bool {
         return blogs.contains { $0.name == blogNameToCheck }
     }
-    
 }

--- a/TILApp/ViewModels/BlogViewModel.swift
+++ b/TILApp/ViewModels/BlogViewModel.swift
@@ -59,7 +59,7 @@ final class BlogViewModel {
     // TODO: 결과 받아와서 blogs에 적용하기
     func setMainBlog(_ id: Int, onSuccess: (() -> Void)? = nil, onError: ((Error) -> Void)? = nil) {
         APIService.shared.request(.setMainBlog(id)) { [weak self] _ in
-            guard let self else { return }
+            guard self != nil else { return }
             
             onSuccess?()
         } onError: { error in
@@ -79,30 +79,4 @@ final class BlogViewModel {
         return blogs.contains { $0.name == blogNameToCheck }
     }
     
-    // TODO: 다 정리되면 위쪽으로 옮기기
-    private(set) var keywords: [KeywordInput] = []
-
-    func clearKeywords() {
-        keywords = []
-    }
-    
-    func initKeywords(blogId: Int) {
-        keywords = (getBlog(blogId: blogId).keywords.map{ KeywordInput.init(from: $0) })
-    }
-
-    func addKeyword(_ keyword: KeywordInput) {
-        keywords.append(keyword)
-    }
-
-    func updateKeyword(_ index: Int, _ keyword: KeywordInput) {
-        keywords[index] = keyword
-    }
-
-    func removeKeyword(index: Int) {
-        keywords.remove(at: index)
-    }
-
-    func hasKeyword(_ keywordToCheck: String) -> Bool {
-        return keywords.contains { $0.keyword == keywordToCheck }
-    }
 }

--- a/TILApp/ViewModels/KeywordInputViewModel.swift
+++ b/TILApp/ViewModels/KeywordInputViewModel.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+final class KeywordInputViewModel {
+    static let shared: KeywordInputViewModel = .init()
+    private init() {}
+    
+    private(set) var keywords: [KeywordInput] = []
+
+    func clearKeywords() {
+        keywords = []
+    }
+    
+    func initKeywords(blogId: Int) {
+        keywords = (BlogViewModel.shared.getBlog(blogId: blogId).keywords.map{ KeywordInput.init(from: $0) })
+    }
+
+    func addKeyword(_ keyword: KeywordInput) {
+        keywords.append(keyword)
+    }
+
+    func updateKeyword(_ index: Int, _ keyword: KeywordInput) {
+        keywords[index] = keyword
+    }
+
+    func removeKeyword(index: Int) {
+        keywords.remove(at: index)
+    }
+
+    func hasKeyword(_ keywordToCheck: String) -> Bool {
+        return keywords.contains { $0.keyword == keywordToCheck }
+    }
+}

--- a/TILApp/ViewModels/KeywordInputViewModel.swift
+++ b/TILApp/ViewModels/KeywordInputViewModel.swift
@@ -6,27 +6,27 @@ final class KeywordInputViewModel {
     
     private(set) var keywords: [KeywordInput] = []
 
-    func clearKeywords() {
+    func clear() {
         keywords = []
     }
     
-    func initKeywords(blogId: Int) {
-        keywords = (BlogViewModel.shared.getBlog(blogId: blogId).keywords.map{ KeywordInput.init(from: $0) })
+    func get(blog: Blog) {
+        keywords = blog.keywords.map{ KeywordInput.init(from: $0) }
     }
 
-    func addKeyword(_ keyword: KeywordInput) {
+    func add(keyword: KeywordInput) {
         keywords.append(keyword)
     }
 
-    func updateKeyword(_ index: Int, _ keyword: KeywordInput) {
+    func update(index: Int, keyword: KeywordInput) {
         keywords[index] = keyword
     }
 
-    func removeKeyword(index: Int) {
+    func remove(index: Int) {
         keywords.remove(at: index)
     }
 
-    func hasKeyword(_ keywordToCheck: String) -> Bool {
+    func has(keywordToCheck: String) -> Bool {
         return keywords.contains { $0.keyword == keywordToCheck }
     }
 }

--- a/TILApp/Views/CommunityView/FollowListViewController.swift
+++ b/TILApp/Views/CommunityView/FollowListViewController.swift
@@ -44,6 +44,7 @@ final class FollowListViewController: UIViewController {
         tableView.pin.top(to: segmentedControl.edge.bottom).horizontally().bottom()
     }
 
+    // TODO: 스크롤 위치 에러 수정
     @objc func segmentedControlSelected(_ control: CustomSegmentedControl) {
         print(scrollRatios)
         let selectedIndex = control.selectedSegmentIndex
@@ -112,6 +113,7 @@ extension FollowListViewController: UITableViewDataSource {
                     cell.customUserView.variant = .unfollow
                     segmentedControl.setTitle("팔로잉 \(userViewModel.followings.count)", forSegmentAt: 1)
                 } onError: { error in
+                    // TODO: 에러 처리
                     print(error)
                 }
 
@@ -121,6 +123,7 @@ extension FollowListViewController: UITableViewDataSource {
                     cell.customUserView.variant = .follow
                     segmentedControl.setTitle("팔로잉 \(userViewModel.followings.count)", forSegmentAt: 1)
                 } onError: { error in
+                    // TODO: 에러 처리
                     print(error)
                 }
             }

--- a/TILApp/Views/MyProfileViewController/BlogEditViewController.swift
+++ b/TILApp/Views/MyProfileViewController/BlogEditViewController.swift
@@ -94,9 +94,12 @@ final class BlogEditViewController: UIViewController {
             style: .destructive,
             handler: { [weak self] _ in
                 guard let self else { return }
-                blogViewModel.deleteBlog(blogId: id)
-                blogViewModel.delete(blog)
-                navigationController?.popViewController(animated: true)
+
+                blogViewModel.delete(blog) {
+                    self.navigationController?.popViewController(animated: true)
+                } onError: { error in
+                    print(error)
+                }
             }
         )
         alertController.addAction(deleteAction)

--- a/TILApp/Views/MyProfileViewController/BlogEditViewController.swift
+++ b/TILApp/Views/MyProfileViewController/BlogEditViewController.swift
@@ -4,12 +4,13 @@ final class BlogEditViewController: UIViewController {
     var id: Int = 0 {
         didSet {
             blog = blogViewModel.getBlog(blogId: id)
-            blogViewModel.initKeywords(blogId: id)
+            keywordInputViewModel.initKeywords(blogId: id)
         }
     }
 
     private lazy var blog: Blog = blogViewModel.getBlog(blogId: id)
     private let blogViewModel = BlogViewModel.shared
+    private let keywordInputViewModel = KeywordInputViewModel.shared
 
     private let contentScrollView = UIScrollView().then {
         $0.showsVerticalScrollIndicator = false
@@ -130,7 +131,7 @@ final class BlogEditViewController: UIViewController {
         view.setNeedsLayout()
 
         let blogKeywords = blog.keywords.map { KeywordInput(from: $0) }
-        if blogKeywords != blogViewModel.keywords {
+        if blogKeywords != keywordInputViewModel.keywords {
             updateDoneButtonState()
         }
     }
@@ -138,7 +139,7 @@ final class BlogEditViewController: UIViewController {
     @objc private func doneButtonTapped() {
         blogViewModel.update(blog, .init(
             name: blogNameTextField.mainText,
-            keywords: blogViewModel.keywords
+            keywords: keywordInputViewModel.keywords
         ), onSuccess: { [weak self] _ in
             guard let self else { return }
             print("블로그가 성공적으로 수정되었습니다.")
@@ -158,7 +159,8 @@ final class BlogEditViewController: UIViewController {
     }
 
     private func updateDoneButtonState() {
-        navigationItem.rightBarButtonItem?.isEnabled = blogViewModel.keywords.count > 0 && blogNameTextField.isValid
+        navigationItem.rightBarButtonItem?.isEnabled
+            = keywordInputViewModel.keywords.count > 0 && blogNameTextField.isValid
     }
 
     override func viewDidLayoutSubviews() {
@@ -167,7 +169,7 @@ final class BlogEditViewController: UIViewController {
         rootFlexContainer.removeAllSubviews()
 
         rootFlexContainer.flex.define {
-            for (index, keyword) in blogViewModel.keywords.enumerated() {
+            for (index, keyword) in keywordInputViewModel.keywords.enumerated() {
                 let customTagView = CustomTagView()
                 customTagView.labelText = keyword.keyword
                 customTagView.tags = keyword.tags
@@ -224,7 +226,7 @@ final class BlogEditViewController: UIViewController {
         if let customTagView = sender.superview as? CustomTagView,
            let index = rootFlexContainer.subviews.firstIndex(of: customTagView)
         {
-            let keyword = blogViewModel.keywords[index]
+            let keyword = keywordInputViewModel.keywords[index]
             let alertController = UIAlertController(
                 title: "태그 삭제",
                 message: "\n\(keyword.keyword)\n\(keyword.tags.joined(separator: ", "))\n\n태그를 삭제하시겠습니까?",
@@ -241,7 +243,7 @@ final class BlogEditViewController: UIViewController {
                 title: "삭제",
                 style: .destructive,
                 handler: { _ in
-                    self.blogViewModel.removeKeyword(index: index)
+                    self.keywordInputViewModel.removeKeyword(index: index)
                     self.updateDoneButtonState()
                     self.view.setNeedsLayout()
                 }

--- a/TILApp/Views/MyProfileViewController/BlogEditViewController.swift
+++ b/TILApp/Views/MyProfileViewController/BlogEditViewController.swift
@@ -4,7 +4,7 @@ final class BlogEditViewController: UIViewController {
     var id: Int = 0 {
         didSet {
             blog = blogViewModel.getBlog(blogId: id)
-            keywordInputViewModel.initKeywords(blogId: id)
+            keywordInputViewModel.get(blog: blog)
         }
     }
 
@@ -98,6 +98,7 @@ final class BlogEditViewController: UIViewController {
                 blogViewModel.delete(blog) {
                     self.navigationController?.popViewController(animated: true)
                 } onError: { error in
+                    // TODO: 에러 처리
                     print(error)
                 }
             }
@@ -151,6 +152,7 @@ final class BlogEditViewController: UIViewController {
                     guard let self else { return }
                     navigationController?.popViewController(animated: true)
                 } onError: { error in
+                    // TODO: 에러 처리
                     print(error)
                 }
             } else {
@@ -246,7 +248,7 @@ final class BlogEditViewController: UIViewController {
                 title: "삭제",
                 style: .destructive,
                 handler: { _ in
-                    self.keywordInputViewModel.removeKeyword(index: index)
+                    self.keywordInputViewModel.remove(index: index)
                     self.updateDoneButtonState()
                     self.view.setNeedsLayout()
                 }

--- a/TILApp/Views/MyProfileViewController/BlogEditViewController.swift
+++ b/TILApp/Views/MyProfileViewController/BlogEditViewController.swift
@@ -73,21 +73,21 @@ final class BlogEditViewController: UIViewController {
         $0.pin.size($0.componentSize)
         $0.addTarget(self, action: #selector(deleteBlogButtonTapped), for: .touchUpInside)
     }
-    
+
     @objc private func deleteBlogButtonTapped() {
         let alertController = UIAlertController(
             title: "블로그 삭제",
             message: "\n블로그를 삭제하시겠습니까?",
             preferredStyle: .alert
         )
-        
+
         let cancelAction = UIAlertAction(
             title: "취소",
             style: .cancel,
             handler: nil
         )
         alertController.addAction(cancelAction)
-        
+
         let deleteAction = UIAlertAction(
             title: "삭제",
             style: .destructive,
@@ -99,7 +99,7 @@ final class BlogEditViewController: UIViewController {
             }
         )
         alertController.addAction(deleteAction)
-        
+
         present(alertController, animated: true, completion: nil)
     }
 
@@ -123,26 +123,31 @@ final class BlogEditViewController: UIViewController {
         contentScrollView.addSubview(contentView)
         contentView.addSubview(rootFlexContainer)
     }
-    
+
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
 
         view.setNeedsLayout()
-        
-        let blogKeywords = blog.keywords.map{ KeywordInput.init(from: $0) }
+
+        let blogKeywords = blog.keywords.map { KeywordInput(from: $0) }
         if blogKeywords != blogViewModel.keywords {
             updateDoneButtonState()
         }
     }
 
     @objc private func doneButtonTapped() {
-        blogViewModel.update(blog, .init(name: blogNameTextField.mainText, keywords: blogViewModel.keywords), onSuccess: { [weak self] updatedBlog in
+        blogViewModel.update(blog, .init(
+            name: blogNameTextField.mainText,
+            keywords: blogViewModel.keywords
+        ), onSuccess: { [weak self] _ in
             guard let self else { return }
             print("블로그가 성공적으로 수정되었습니다.")
             if mainBlogButton.variant == .primary {
                 blogViewModel.setMainBlog(id) { [weak self] in
                     guard let self else { return }
                     navigationController?.popViewController(animated: true)
+                } onError: { error in
+                    print(error)
                 }
             } else {
                 navigationController?.popViewController(animated: true)
@@ -151,7 +156,7 @@ final class BlogEditViewController: UIViewController {
             print("블로그 수정 중 오류 발생: \(error)")
         })
     }
-    
+
     private func updateDoneButtonState() {
         navigationItem.rightBarButtonItem?.isEnabled = blogViewModel.keywords.count > 0 && blogNameTextField.isValid
     }
@@ -169,12 +174,14 @@ final class BlogEditViewController: UIViewController {
                 $0.addItem(customTagView).marginTop(10)
                 customTagView.pin.size(customTagView.componentSize)
 
-                let tapGestureRecognizer = ContextTapGestureRecognizer(target: self, action: #selector(customTagViewTapped(_:)))
+                let tapGestureRecognizer
+                    = ContextTapGestureRecognizer(target: self, action: #selector(customTagViewTapped(_:)))
                 tapGestureRecognizer.context["index"] = index
                 customTagView.addGestureRecognizer(tapGestureRecognizer)
                 customTagView.isUserInteractionEnabled = true
 
-                customTagView.addTargetForButton(target: self, action: #selector(deleteTagButtonTapped), for: .touchUpInside)
+                customTagView
+                    .addTargetForButton(target: self, action: #selector(deleteTagButtonTapped), for: .touchUpInside)
             }
         }
 
@@ -256,12 +263,14 @@ extension BlogEditViewController: UITextFieldDelegate {
         return true
     }
 
-    func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
+    func textField(
+        _ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String
+    ) -> Bool {
         if let currentText = textField.text,
            let range = Range(range, in: currentText)
         {
             let updatedText = currentText.replacingCharacters(in: range, with: string)
-            
+
             if updatedText.isEmpty {
                 blogNameTextField.isValid = false
                 blogNameTextField.validationText = ""
@@ -273,10 +282,10 @@ extension BlogEditViewController: UITextFieldDelegate {
                 blogNameTextField.isValid = !isDuplicate
                 blogNameTextField.validationText = isDuplicate ? "이미 등록된 블로그 이름입니다." : "유효한 블로그 이름입니다."
             }
-            
+
             updateDoneButtonState()
         }
-        
+
         return true
     }
 }

--- a/TILApp/Views/MyProfileViewController/BlogListTableViewCell.swift
+++ b/TILApp/Views/MyProfileViewController/BlogListTableViewCell.swift
@@ -1,11 +1,3 @@
-//
-//  BlogListTableViewCell.swift
-//  TILApp
-//
-//  Created by 이재희 on 10/19/23.
-//
-
-import PinLayout
 import UIKit
 
 final class BlogListTableViewCell: UITableViewCell {

--- a/TILApp/Views/MyProfileViewController/BlogListViewController.swift
+++ b/TILApp/Views/MyProfileViewController/BlogListViewController.swift
@@ -1,10 +1,3 @@
-//
-//  BlogListViewController.swift
-//  TILApp
-//
-//  Created by 이재희 on 10/19/23.
-//
-
 import UIKit
 
 final class BlogListViewController: UIViewController {
@@ -21,7 +14,8 @@ final class BlogListViewController: UIViewController {
         view.backgroundColor = .systemBackground
         title = "블로그 목록"
 
-        let addBlogButton = UIBarButtonItem(title: "추가", style: .plain, target: self, action: #selector(addBlogButtonTapped))
+        let addBlogButton
+            = UIBarButtonItem(title: "추가", style: .plain, target: self, action: #selector(addBlogButtonTapped))
         navigationItem.rightBarButtonItem = addBlogButton
 
         view.addSubview(tableView)
@@ -61,7 +55,9 @@ extension BlogListViewController: UITableViewDataSource {
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        guard let cell = tableView.dequeueReusableCell(withIdentifier: "CustomBlogCell", for: indexPath) as? BlogListTableViewCell else {
+        guard let cell
+            = tableView.dequeueReusableCell(withIdentifier: "CustomBlogCell", for: indexPath) as? BlogListTableViewCell
+        else {
             return UITableViewCell()
         }
 

--- a/TILApp/Views/MyProfileViewController/BlogListViewController.swift
+++ b/TILApp/Views/MyProfileViewController/BlogListViewController.swift
@@ -33,9 +33,6 @@ final class BlogListViewController: UIViewController {
         tabBarController?.tabBar.isHidden = true
 
         KeywordInputViewModel.shared.clearKeywords()
-//        blogViewModel.load(onSuccess: { [weak self] _ in
-//            self?.tableView.reloadData()
-//        })
         tableView.reloadData()
     }
 

--- a/TILApp/Views/MyProfileViewController/BlogListViewController.swift
+++ b/TILApp/Views/MyProfileViewController/BlogListViewController.swift
@@ -32,7 +32,7 @@ final class BlogListViewController: UIViewController {
         navigationController?.isNavigationBarHidden = false
         tabBarController?.tabBar.isHidden = true
 
-        blogViewModel.clearKeywords()
+        KeywordInputViewModel.shared.clearKeywords()
         blogViewModel.load(onSuccess: { [weak self] _ in
             self?.tableView.reloadData()
         })

--- a/TILApp/Views/MyProfileViewController/BlogListViewController.swift
+++ b/TILApp/Views/MyProfileViewController/BlogListViewController.swift
@@ -33,9 +33,10 @@ final class BlogListViewController: UIViewController {
         tabBarController?.tabBar.isHidden = true
 
         KeywordInputViewModel.shared.clearKeywords()
-        blogViewModel.load(onSuccess: { [weak self] _ in
-            self?.tableView.reloadData()
-        })
+//        blogViewModel.load(onSuccess: { [weak self] _ in
+//            self?.tableView.reloadData()
+//        })
+        tableView.reloadData()
     }
 
     override func viewDidLayoutSubviews() {

--- a/TILApp/Views/MyProfileViewController/BlogListViewController.swift
+++ b/TILApp/Views/MyProfileViewController/BlogListViewController.swift
@@ -32,7 +32,7 @@ final class BlogListViewController: UIViewController {
         navigationController?.isNavigationBarHidden = false
         tabBarController?.tabBar.isHidden = true
 
-        KeywordInputViewModel.shared.clearKeywords()
+        KeywordInputViewModel.shared.clear()
         tableView.reloadData()
     }
 

--- a/TILApp/Views/MyProfileViewController/BlogRegisterViewController.swift
+++ b/TILApp/Views/MyProfileViewController/BlogRegisterViewController.swift
@@ -175,6 +175,7 @@ final class BlogRegisterViewController: UIViewController, UIGestureRecognizerDel
     }
 
     private func isValidURL(_ urlString: String) -> Bool {
+        guard !urlString.hasSuffix("/") else { return false }
         if let url = URL(string: urlString) {
             return UIApplication.shared.canOpenURL(url)
         }
@@ -270,8 +271,9 @@ extension BlogRegisterViewController: UITextFieldDelegate {
         } else {
             // TODO: URL 유효성 검사
             if isValidURL(text) {
-                blogURLTextField.isValid = true
-                blogURLTextField.validationText = "유효한 블로그 주소입니다."
+                let isDuplicate = blogViewModel.hasBlogURL(text)
+                blogURLTextField.isValid = !isDuplicate
+                blogURLTextField.validationText = isDuplicate ? "이미 등록된 블로그 URL입니다." : "유효한 블로그 URL입니다."
             } else {
                 blogURLTextField.isValid = false
                 blogURLTextField.validationText = "유효하지 않은 URL입니다."

--- a/TILApp/Views/MyProfileViewController/BlogRegisterViewController.swift
+++ b/TILApp/Views/MyProfileViewController/BlogRegisterViewController.swift
@@ -21,6 +21,7 @@ final class BlogRegisterViewController: UIViewController, UIGestureRecognizerDel
         $0.titleText = "블로그 주소"
         $0.placeholder = "블로그 주소를 입력해 주세요"
         $0.textFieldTag = 1
+        $0.keyboardType = .URL
         $0.delegate = self
         contentView.addSubview($0)
     }
@@ -29,6 +30,7 @@ final class BlogRegisterViewController: UIViewController, UIGestureRecognizerDel
         $0.titleText = "블로그 RSS 주소"
         $0.placeholder = "블로그 RSS 주소를 입력해 주세요"
         $0.textFieldTag = 2
+        $0.keyboardType = .URL
         $0.delegate = self
         contentView.addSubview($0)
     }
@@ -265,7 +267,7 @@ extension BlogRegisterViewController: UITextFieldDelegate {
             blogURLTextField.isValid = false
             blogURLTextField.validationText = ""
         } else {
-            // URL 유효성 검사
+            // TODO: URL 유효성 검사
             if isValidURL(text) {
                 blogURLTextField.isValid = true
                 blogURLTextField.validationText = "유효한 블로그 주소입니다."

--- a/TILApp/Views/MyProfileViewController/BlogRegisterViewController.swift
+++ b/TILApp/Views/MyProfileViewController/BlogRegisterViewController.swift
@@ -77,7 +77,7 @@ final class BlogRegisterViewController: UIViewController, UIGestureRecognizerDel
         }, onError: { error in
             print("블로그 생성 중 오류 발생: \(error)")
         })
-        keywordInputViewModel.clearKeywords()
+        keywordInputViewModel.clear()
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -161,7 +161,7 @@ final class BlogRegisterViewController: UIViewController, UIGestureRecognizerDel
                 title: "삭제",
                 style: .destructive,
                 handler: { _ in
-                    self.keywordInputViewModel.removeKeyword(index: index)
+                    self.keywordInputViewModel.remove(index: index)
                     self.updateDoneButtonState()
                     self.view.setNeedsLayout()
                 }

--- a/TILApp/Views/MyProfileViewController/BlogRegisterViewController.swift
+++ b/TILApp/Views/MyProfileViewController/BlogRegisterViewController.swift
@@ -212,24 +212,6 @@ extension BlogRegisterViewController: UITextFieldDelegate {
         return true
     }
 
-    func convertToRssUrl(from blogUrl: String) -> String? {
-        var separateUrl = blogUrl.components(separatedBy: "https://").joined()
-        separateUrl = separateUrl.components(separatedBy: "/rss").joined()
-        separateUrl = separateUrl.components(separatedBy: "/feed").joined()
-        let splitUrl = separateUrl.split(separator: "/")
-
-        if splitUrl[0].contains("tistory.com") {
-            return "https://" + splitUrl[0] + "/rss"
-        } else if splitUrl[0].contains("naver.com") {
-            return "https://" + "rss." + "blog.naver.com/" + splitUrl[1]
-        } else if splitUrl[0].contains("velog.io") {
-            return "https://" + "v2." + "velog.io/rss/" + splitUrl[1]
-        } else if splitUrl[0].contains("medium.com") {
-            return "https://" + "medium.com/feed/" + splitUrl[1]
-        }
-        return nil
-    }
-
     func textField(
         _ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String
     ) -> Bool {

--- a/TILApp/Views/MyProfileViewController/BlogRegisterViewController.swift
+++ b/TILApp/Views/MyProfileViewController/BlogRegisterViewController.swift
@@ -2,6 +2,7 @@ import UIKit
 
 final class BlogRegisterViewController: UIViewController, UIGestureRecognizerDelegate {
     private let blogViewModel = BlogViewModel.shared
+    private let keywordInputViewModel = KeywordInputViewModel.shared
 
     private let contentScrollView = UIScrollView().then {
         $0.showsVerticalScrollIndicator = false
@@ -68,7 +69,7 @@ final class BlogRegisterViewController: UIViewController, UIGestureRecognizerDel
             name: blogNameTextField.mainText,
             url: blogURLTextField.mainText,
             rss: blogRSSTextField.mainText,
-            keywords: blogViewModel.keywords
+            keywords: keywordInputViewModel.keywords
         ), onSuccess: { [weak self] _ in
             guard let self = self else { return }
             print("블로그가 성공적으로 생성되었습니다.")
@@ -76,7 +77,7 @@ final class BlogRegisterViewController: UIViewController, UIGestureRecognizerDel
         }, onError: { error in
             print("블로그 생성 중 오류 발생: \(error)")
         })
-        blogViewModel.clearKeywords()
+        keywordInputViewModel.clearKeywords()
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -94,7 +95,7 @@ final class BlogRegisterViewController: UIViewController, UIGestureRecognizerDel
         rootFlexContainer.removeAllSubviews()
 
         rootFlexContainer.flex.define {
-            for (index, keyword) in blogViewModel.keywords.enumerated() {
+            for (index, keyword) in keywordInputViewModel.keywords.enumerated() {
                 let customTagView = CustomTagView()
                 customTagView.labelText = keyword.keyword
                 customTagView.tags = keyword.tags
@@ -143,7 +144,7 @@ final class BlogRegisterViewController: UIViewController, UIGestureRecognizerDel
         if let customTagView = sender.superview as? CustomTagView,
            let index = rootFlexContainer.subviews.firstIndex(of: customTagView)
         {
-            let keyword = blogViewModel.keywords[index]
+            let keyword = keywordInputViewModel.keywords[index]
             let alertController = UIAlertController(
                 title: "태그 삭제",
                 message: "\n\(keyword.keyword)\n\(keyword.tags.joined(separator: ", "))\n\n태그를 삭제하시겠습니까?",
@@ -160,7 +161,7 @@ final class BlogRegisterViewController: UIViewController, UIGestureRecognizerDel
                 title: "삭제",
                 style: .destructive,
                 handler: { _ in
-                    self.blogViewModel.removeKeyword(index: index)
+                    self.keywordInputViewModel.removeKeyword(index: index)
                     self.updateDoneButtonState()
                     self.view.setNeedsLayout()
                 }
@@ -182,7 +183,7 @@ final class BlogRegisterViewController: UIViewController, UIGestureRecognizerDel
 
     private func updateDoneButtonState() {
         navigationItem.rightBarButtonItem?.isEnabled
-            = blogViewModel.keywords.count > 0 && blogNameTextField.isValid
+            = keywordInputViewModel.keywords.count > 0 && blogNameTextField.isValid
             && blogURLTextField.isValid && blogRSSTextField.isValid
     }
 }

--- a/TILApp/Views/MyProfileViewController/EditTagViewController.swift
+++ b/TILApp/Views/MyProfileViewController/EditTagViewController.swift
@@ -158,10 +158,12 @@ extension EditTagViewController: UITextFieldDelegate {
             if textField.tag == 0 {
                 textField.resignFirstResponder()
             } else if textField.tag == 1 {
-                keyword.tags.append(text)
-                updateDoneButtonState()
+                if !keyword.tags.contains(text) {
+                    keyword.tags.append(text)
+                    updateDoneButtonState()
+                    collectionView.reloadData()
+                }
                 textField.text = ""
-                collectionView.reloadData()
             }
         }
         return true

--- a/TILApp/Views/MyProfileViewController/EditTagViewController.swift
+++ b/TILApp/Views/MyProfileViewController/EditTagViewController.swift
@@ -92,9 +92,9 @@ final class EditTagViewController: UIViewController {
         keyword.keyword = prefixTF.mainText
         switch variant {
         case .add:
-            keywordInputViewModel.addKeyword(keyword)
+            keywordInputViewModel.add(keyword: keyword)
         case .update:
-            keywordInputViewModel.updateKeyword(selectedIndex, keyword)
+            keywordInputViewModel.update(index: selectedIndex, keyword: keyword)
         }
 
         navigationController?.popViewController(animated: true)
@@ -183,7 +183,7 @@ extension EditTagViewController: UITextFieldDelegate {
                     prefixTF.isValid = true
                     prefixTF.validationText = ""
                 } else {
-                    let isDuplicate = keywordInputViewModel.hasKeyword(updatedText)
+                    let isDuplicate = keywordInputViewModel.has(keywordToCheck: updatedText)
                     prefixTF.isValid = !isDuplicate
                     prefixTF.validationText = isDuplicate ? "중복된 키워드입니다." : "유효한 키워드입니다."
                 }

--- a/TILApp/Views/MyProfileViewController/EditTagViewController.swift
+++ b/TILApp/Views/MyProfileViewController/EditTagViewController.swift
@@ -21,7 +21,7 @@ final class EditTagViewController: UIViewController {
                 title = "키워드 등록"
             case .update:
                 title = "키워드 수정"
-                keyword = blogViewModel.keywords[selectedIndex]
+                keyword = keywordInputViewModel.keywords[selectedIndex]
             }
         }
     }
@@ -30,6 +30,7 @@ final class EditTagViewController: UIViewController {
     var keyword: KeywordInput = .init(keyword: "", tags: [])
 
     private let blogViewModel = BlogViewModel.shared
+    private let keywordInputViewModel = KeywordInputViewModel.shared
 
     private lazy var prefixTF = CustomTextFieldViewWithValidation().then {
         $0.titleText = "게시물 제목에 포함될 문자"
@@ -91,9 +92,9 @@ final class EditTagViewController: UIViewController {
         keyword.keyword = prefixTF.mainText
         switch variant {
         case .add:
-            blogViewModel.addKeyword(keyword)
+            keywordInputViewModel.addKeyword(keyword)
         case .update:
-            blogViewModel.updateKeyword(selectedIndex, keyword)
+            keywordInputViewModel.updateKeyword(selectedIndex, keyword)
         }
 
         navigationController?.popViewController(animated: true)
@@ -180,7 +181,7 @@ extension EditTagViewController: UITextFieldDelegate {
                     prefixTF.isValid = true
                     prefixTF.validationText = ""
                 } else {
-                    let isDuplicate = blogViewModel.hasKeyword(updatedText)
+                    let isDuplicate = keywordInputViewModel.hasKeyword(updatedText)
                     prefixTF.isValid = !isDuplicate
                     prefixTF.validationText = isDuplicate ? "중복된 키워드입니다." : "유효한 키워드입니다."
                 }

--- a/TILApp/Views/Shared/Components/CustomTextFieldView.swift
+++ b/TILApp/Views/Shared/Components/CustomTextFieldView.swift
@@ -26,6 +26,11 @@ class CustomTextFieldView: UIView {
         get { textField.delegate }
         set { textField.delegate = newValue }
     }
+    
+    var keyboardType: UIKeyboardType {
+        get { textField.keyboardType }
+        set { textField.keyboardType = newValue }
+    }
 
     var readOnly: Bool = false {
         didSet {

--- a/TILApp/Views/Shared/Components/CustomTextFieldViewWithValidation.swift
+++ b/TILApp/Views/Shared/Components/CustomTextFieldViewWithValidation.swift
@@ -25,6 +25,11 @@ class CustomTextFieldViewWithValidation: UIView {
         get { customTextFieldView.delegate }
         set { customTextFieldView.delegate = newValue }
     }
+    
+    var keyboardType: UIKeyboardType {
+        get { customTextFieldView.keyboardType }
+        set { customTextFieldView.keyboardType = newValue }
+    }
 
     var readOnly: Bool = false {
         didSet {


### PR DESCRIPTION
## 작업한 내용 설명

현재 브랜치에서 작업한 내용을 간단히 설명합니다.
- 블로그 등록 시 rss 자동입력 기능 추가 (키보드 리턴 입력 시 자동입력됨)
- 블로그 등록 시 url, rss 텍스트필드 키보드 타입 변경
-  KeywordIput 모델 파일 분리
- 자동 태그 중복 방지
- 대표블로그 설정 시 블로그 새로 load하도록 설정
- 블로그 url 중복 입력 및 url suffix / 입력 방지

---

<img src="https://github.com/nbcamp/til-app/assets/74818845/a40253c7-c980-4eda-9285-eae20bff0116" width="300">

![Simulator Screen Recording - iPhone 15 Pro - 2023-11-01 at 14 42 42](https://github.com/nbcamp/til-app/assets/74818845/a12986cf-c3ee-4c44-a139-eabb9d94b904)


![Simulator Screen Recording - iPhone 15 Pro - 2023-11-01 at 14 46 03](https://github.com/nbcamp/til-app/assets/74818845/5a93a568-4e68-402e-b526-ec334ae9547f)


---

resolve #68 
