### PR TITLE
[Fix] 프로필 이미지 타원형 문제 수정 #113

### DIFF
--- a/TILApp/Views/CommunityView/UserProfileViewController.swift
+++ b/TILApp/Views/CommunityView/UserProfileViewController.swift
@@ -117,7 +117,7 @@ final class UserProfileViewController: UIViewController {
 
     private func setUpUI() {
         screenView.flex.addItem().direction(.row).marginLeft(10).define { flex in
-            flex.addItem(profileImageView).width(100).height(100).marginLeft(10)
+            flex.addItem(profileImageView).width(103).height(100).cornerRadius(100 / 2).marginLeft(10)
             flex.addItem().direction(.column).width(200).define { flex in
                 flex.addItem(nicknameLabel).width(200).height(25).marginLeft(20).marginTop(5)
                 flex.addItem(countView).direction(.row).width(200).height(75)

--- a/TILApp/Views/MyProfileViewController/MyProfileViewController.swift
+++ b/TILApp/Views/MyProfileViewController/MyProfileViewController.swift
@@ -112,7 +112,7 @@ final class MyProfileViewController: UIViewController {
     private func setUpUI() {
         screenView.flex.direction(.column).define { flex in
             flex.addItem().direction(.row).define { flex in
-                flex.addItem(profileImageView).width(100).height(100).cornerRadius(100 / 2)
+                flex.addItem(profileImageView).width(103).height(100).cornerRadius(100 / 2)
                 flex.addItem().direction(.column).define { flex in
                     flex.addItem(nicknameLabel).marginLeft(15).marginTop(10)
                     flex.addItem(countView)


### PR DESCRIPTION
## 작업한 내용 설명

[Fix] 프로필 이미지 타원형 문제 수정

## UI 변경 작업물
<img width="309" alt="스크린샷 2023-11-08 오후 7 24 54" src="https://github.com/nbcamp/til-app/assets/139327412/b43fcf17-0786-4f8f-b707-f8a10ac85b2c">

---

resolve #113 
