### PR TITLE
[Fix] 블로그 게시글 불러오기 안 되는 문제 수정 #173

### DIFF
--- a/TILApp/Models/User.swift
+++ b/TILApp/Models/User.swift
@@ -27,4 +27,3 @@ struct UpdateUserInput: Codable {
 struct ReportUserInput: Codable {
     let reason: String
 }
-

--- a/TILApp/Services/RssService.swift
+++ b/TILApp/Services/RssService.swift
@@ -33,7 +33,7 @@ final class RssService {
                           let url = post.link,
                           let pubDate = post.pubDate,
                           let publishedAt = toDate(string: pubDate, formats: [
-                              "EEE, dd MMM yyyy HH:mm:ss z",
+                              "EEE, dd MMM yyyy HH:mm:ss Z",
                           ])
                     else { return nil }
 

--- a/TILApp/Utilities/converter.swift
+++ b/TILApp/Utilities/converter.swift
@@ -28,6 +28,7 @@ func convertToRssUrl(from blogUrl: String) -> String? {
 
 func toDate(string: String, formats: [String]) -> Date? {
     let formatter = DateFormatter()
+    formatter.locale = .init(identifier: "en_US")
     for format in formats {
         formatter.dateFormat = format
         if let date = formatter.date(from: string) {

--- a/TILApp/ViewModels/RssViewModel.swift
+++ b/TILApp/ViewModels/RssViewModel.swift
@@ -78,7 +78,9 @@ final class RssViewModel {
             do {
                 let posts = try await rss.loadDocument(url: blog.rss)
                 for post in posts {
-                    guard let keywordMap = (blog.keywords.first { post.title.contains($0.keyword) }) else { continue }
+                    guard let keywordMap = (blog.keywords.first {
+                        post.title.localizedStandardContains($0.keyword)
+                    }) else { continue }
                     allPosts.append(.init(
                         blog: blog,
                         title: post.title,

--- a/TILApp/ViewModels/RssViewModel.swift
+++ b/TILApp/ViewModels/RssViewModel.swift
@@ -53,7 +53,7 @@ final class RssViewModel {
                 await prepareDatasets(blogs: blogs)
                 findStartOfStreakDays()
 
-                await sendPostsToServer(lastPublishedAt: authUser.lastPublishedAt)
+                await sendPostsToServer()
                 completion?(true)
             } catch {
                 debugPrint(#function, error)
@@ -104,11 +104,12 @@ final class RssViewModel {
         }
     }
 
-    private func sendPostsToServer(lastPublishedAt: Date?) async {
+    private func sendPostsToServer() async {
         for (blogId, posts) in postsByBlogMap {
             for post in posts {
                 do {
-                    guard lastPublishedAt == nil || post.publishedAt > lastPublishedAt! else { return }
+                    guard post.blog.lastPublishedAt == nil
+                        || post.publishedAt > post.blog.lastPublishedAt! else { return }
                     _ = try await api.request(.createMyBlogPost(blogId, .init(
                         title: post.title,
                         content: post.content,

--- a/TILApp/Views/AuthView/SignInViewController.swift
+++ b/TILApp/Views/AuthView/SignInViewController.swift
@@ -77,13 +77,11 @@ extension SignInViewController: ASAuthorizationControllerDelegate {
             let userIdentifier = appleIDCredential.user
             let fullName = appleIDCredential.fullName
 
-            var username: String?
-            if fullName != nil {
-                username = (fullName?.familyName ?? "") + (fullName?.givenName ?? "")
-            }
+            var username = (fullName?.familyName ?? "") + (fullName?.givenName ?? "")
+            username = username.trimmingCharacters(in: .whitespacesAndNewlines)
 
             AuthViewModel.shared.signIn(.init(
-                username: username ?? "이름없음",
+                username: username.isEmpty ? "이름없음" : username,
                 avatarUrl: nil,
                 provider: "APPLE",
                 providerId: userIdentifier

--- a/TILApp/Views/CalendarView/CalendarViewController.swift
+++ b/TILApp/Views/CalendarView/CalendarViewController.swift
@@ -160,6 +160,11 @@ final class CalendarViewController: UIViewController, UIGestureRecognizerDelegat
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         navigationController?.setNavigationBarHidden(true, animated: true)
+
+        if hasBlog {
+            flexContainer.removeFromSuperview()
+        }
+
         WKWebViewWarmer.shared.prepare()
     }
 

--- a/TILApp/Views/MyProfileViewController/BlogEditViewController.swift
+++ b/TILApp/Views/MyProfileViewController/BlogEditViewController.swift
@@ -147,6 +147,7 @@ final class BlogEditViewController: UIViewController {
                 debugPrint(#function, error)
                 return
             }
+            RssViewModel.shared.reload()
             navigationController?.popViewController(animated: true)
         }
     }


### PR DESCRIPTION
## 작업한 내용 설명

- fix: 블로그 게시글 불러오기 안 되는 문제 수정
- fix: 사용자 이름 없을 때 이름없음으로 수정
- fix: 블로그 추가 시 달력 화면으로 변경되도록 수정
- fix: 블로그 정보 변경 시에 새로 불러오도록 개선


---

resolve #173
resolve #174 
resolve #175
