### PR TITLE
[Feat] 로그인 화면 띄우는 방식 개선 #187 #188

### DIFF
--- a/TILApp.xcodeproj/project.pbxproj
+++ b/TILApp.xcodeproj/project.pbxproj
@@ -54,6 +54,7 @@
 		33E1D1DD2B012524007DEEE8 /* AvatarImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33E1D1DC2B012524007DEEE8 /* AvatarImageView.swift */; };
 		33E1D1DF2B0133D0007DEEE8 /* WebViewWarmer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33E1D1DE2B0133D0007DEEE8 /* WebViewWarmer.swift */; };
 		33E1D1E12B016545007DEEE8 /* UIImage+Ext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33E1D1E02B016545007DEEE8 /* UIImage+Ext.swift */; };
+		33E1D1E72B048DC5007DEEE8 /* ViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33E1D1E62B048DC5007DEEE8 /* ViewModel.swift */; };
 		9B859B2B2AE26C2600025E8B /* ProfileEditViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B859B2A2AE26C2600025E8B /* ProfileEditViewController.swift */; };
 		9BB3AD6F2AEEC99F004A25DB /* MyProfileTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BB3AD6E2AEEC99F004A25DB /* MyProfileTableViewCell.swift */; };
 		9BE049B92AEB968E00A47CFC /* WebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BE049B82AEB968E00A47CFC /* WebViewController.swift */; };
@@ -143,6 +144,7 @@
 		33E1D1DC2B012524007DEEE8 /* AvatarImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AvatarImageView.swift; sourceTree = "<group>"; };
 		33E1D1DE2B0133D0007DEEE8 /* WebViewWarmer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewWarmer.swift; sourceTree = "<group>"; };
 		33E1D1E02B016545007DEEE8 /* UIImage+Ext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+Ext.swift"; sourceTree = "<group>"; };
+		33E1D1E62B048DC5007DEEE8 /* ViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewModel.swift; sourceTree = "<group>"; };
 		9B859B2A2AE26C2600025E8B /* ProfileEditViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileEditViewController.swift; sourceTree = "<group>"; };
 		9BB3AD6E2AEEC99F004A25DB /* MyProfileTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyProfileTableViewCell.swift; sourceTree = "<group>"; };
 		9BE049B82AEB968E00A47CFC /* WebViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewController.swift; sourceTree = "<group>"; };
@@ -258,6 +260,7 @@
 		3334E1C02AD910DB00D853D7 /* ViewModels */ = {
 			isa = PBXGroup;
 			children = (
+				33E1D1E62B048DC5007DEEE8 /* ViewModel.swift */,
 				3334E1D82AD9181F00D853D7 /* AuthViewModel.swift */,
 				33A4E8232AECB4C700E3F55E /* UserViewModel.swift */,
 				33A4E81B2AEBB14800E3F55E /* BlogViewModel.swift */,
@@ -615,6 +618,7 @@
 				33A4E8322AEFCA7100E3F55E /* LoadingViewController.swift in Sources */,
 				D2CDB70B2AEB68DB00BFD8C2 /* CustomCommunityTILView.swift in Sources */,
 				9BE049C02AED229600A47CFC /* UserProfileViewController.swift in Sources */,
+				33E1D1E72B048DC5007DEEE8 /* ViewModel.swift in Sources */,
 				D29659F22AE80313000C28A6 /* EditTagViewController.swift in Sources */,
 				33A4E81E2AEBB24A00E3F55E /* Exported.swift in Sources */,
 				3334E1EE2AD919F500D853D7 /* SignInViewController.swift in Sources */,

--- a/TILApp/Models/AuthUser.swift
+++ b/TILApp/Models/AuthUser.swift
@@ -12,7 +12,7 @@ struct AuthUser: Codable {
 }
 
 struct SignInInput: Codable {
-    let username: String
+    let username: String?
     let avatarUrl: String?
     let provider: String
     let providerId: String

--- a/TILApp/Resources/SceneDelegate.swift
+++ b/TILApp/Resources/SceneDelegate.swift
@@ -5,6 +5,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     private var cancellables: Set<AnyCancellable> = []
     private var initialized = false
+    private var needToReset = false
 
     func scene(_ scene: UIScene, willConnectTo _: UISceneSession, options _: UIScene.ConnectionOptions) {
         guard let windowScene = (scene as? UIWindowScene) else { return }
@@ -13,11 +14,29 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         window.makeKeyAndVisible()
 
         window.rootViewController = LoadingViewController()
-        AuthViewModel.shared.$isAuthenticated.dropFirst().sink { isAuthenticated in
-            if isAuthenticated, window.rootViewController is SignInViewController {
+
+        AuthViewModel.shared.$isAuthenticated.dropFirst().sink { [unowned self] isAuthenticated in
+            guard initialized else { return }
+            if window.rootViewController is LoadingViewController {
                 window.rootViewController = RootViewController()
+            }
+
+            if isAuthenticated, let rootVC = window.rootViewController as? RootViewController {
+                if needToReset {
+                    needToReset = false
+                    rootVC._tabBarController?.selectedIndex = 0
+                }
+                rootVC.dismiss(animated: true)
             } else if !isAuthenticated {
-                window.rootViewController = SignInViewController()
+                UserViewModel.reset()
+                BlogViewModel.reset()
+                PostViewModel.reset()
+                CommunityViewModel.reset()
+                RssViewModel.reset()
+                needToReset = true
+                let signInVC = SignInViewController()
+                signInVC.modalPresentationStyle = .fullScreen
+                window.rootViewController?.present(signInVC, animated: true)
             }
         }.store(in: &cancellables)
 
@@ -26,14 +45,11 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             case .success:
                 window.rootViewController = RootViewController()
             case .failure:
-                AuthViewModel.reset()
-                UserViewModel.reset()
-                BlogViewModel.reset()
-                PostViewModel.reset()
-                CommunityViewModel.reset()
-                RssViewModel.reset()
-                window.rootViewController = SignInViewController()
+                let signInVC = SignInViewController()
+                signInVC.modalPresentationStyle = .fullScreen
+                window.rootViewController?.present(signInVC, animated: false)
             }
+
             initialized = true
         }
 

--- a/TILApp/Resources/SceneDelegate.swift
+++ b/TILApp/Resources/SceneDelegate.swift
@@ -23,8 +23,16 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
         AuthViewModel.shared.checkAuthorization { [unowned self] result in
             switch result {
-            case .success: window.rootViewController = RootViewController()
-            case .failure: window.rootViewController = SignInViewController()
+            case .success:
+                window.rootViewController = RootViewController()
+            case .failure:
+                AuthViewModel.reset()
+                UserViewModel.reset()
+                BlogViewModel.reset()
+                PostViewModel.reset()
+                CommunityViewModel.reset()
+                RssViewModel.reset()
+                window.rootViewController = SignInViewController()
             }
             initialized = true
         }

--- a/TILApp/Utilities/Extensions/Date+Ext.swift
+++ b/TILApp/Utilities/Extensions/Date+Ext.swift
@@ -17,8 +17,8 @@ extension Date {
         let components = calendar.dateComponents([.year, .month, .day], from: self)
         return calendar.date(from: components)!
     }
-    
-    var startOfMonth:  Date {
+
+    var startOfMonth: Date {
         let calendar = Calendar.current
         let components = calendar.dateComponents([.year, .month], from: self)
         return calendar.date(from: components)!

--- a/TILApp/ViewModels/AuthViewModel.swift
+++ b/TILApp/ViewModels/AuthViewModel.swift
@@ -1,7 +1,8 @@
 import Foundation
 
-final class AuthViewModel {
-    static let shared: AuthViewModel = .init()
+final class AuthViewModel: ViewModel {
+    static var shared: AuthViewModel = .init()
+    static func reset() { shared = .init() }
     private init() {}
 
     private let api = APIService.shared

--- a/TILApp/ViewModels/BlogViewModel.swift
+++ b/TILApp/ViewModels/BlogViewModel.swift
@@ -1,5 +1,6 @@
-final class BlogViewModel {
-    static let shared: BlogViewModel = .init()
+final class BlogViewModel: ViewModel {
+    static var shared: BlogViewModel = .init()
+    static func reset() { shared = .init() }
     private init() {}
 
     private(set) var blogs: [Blog] = []

--- a/TILApp/ViewModels/CommunityViewModel.swift
+++ b/TILApp/ViewModels/CommunityViewModel.swift
@@ -8,8 +8,9 @@ protocol CommunityViewModelDelegate: AnyObject {
     func errorOccurred(_ viewModel: CommunityViewModel, error: String)
 }
 
-final class CommunityViewModel {
-    static let shared: CommunityViewModel = .init()
+final class CommunityViewModel: ViewModel {
+    static var shared: CommunityViewModel = .init()
+    static func reset() { shared = .init() }
     private init() {}
 
     weak var delegate: CommunityViewModelDelegate?

--- a/TILApp/ViewModels/PostViewModel.swift
+++ b/TILApp/ViewModels/PostViewModel.swift
@@ -1,8 +1,9 @@
 import Dispatch
 import Foundation
 
-final class PostViewModel {
-    static let shared: PostViewModel = .init()
+final class PostViewModel: ViewModel {
+    static var shared: PostViewModel = .init()
+    static func reset() { shared = .init() }
     private init() {}
 
     private let api = APIService.shared

--- a/TILApp/ViewModels/RssViewModel.swift
+++ b/TILApp/ViewModels/RssViewModel.swift
@@ -2,8 +2,9 @@ import Combine
 import Foundation
 import XMLCoder
 
-final class RssViewModel {
-    static let shared: RssViewModel = .init()
+final class RssViewModel: ViewModel {
+    static var shared: RssViewModel = .init()
+    static func reset() { shared = .init() }
     private init() {}
 
     struct Post {

--- a/TILApp/ViewModels/UserViewModel.swift
+++ b/TILApp/ViewModels/UserViewModel.swift
@@ -1,7 +1,8 @@
 import Moya
 
-final class UserViewModel {
-    static let shared: UserViewModel = .init()
+final class UserViewModel: ViewModel {
+    static var shared: UserViewModel = .init()
+    static func reset() { shared = .init() }
     private init() {}
 
     private let api = APIService.shared

--- a/TILApp/ViewModels/ViewModel.swift
+++ b/TILApp/ViewModels/ViewModel.swift
@@ -1,0 +1,4 @@
+protocol ViewModel {
+    static var shared: Self { get set }
+    static func reset()
+}

--- a/TILApp/Views/AuthView/SignInViewController.swift
+++ b/TILApp/Views/AuthView/SignInViewController.swift
@@ -81,7 +81,7 @@ extension SignInViewController: ASAuthorizationControllerDelegate {
             username = username.trimmingCharacters(in: .whitespacesAndNewlines)
 
             AuthViewModel.shared.signIn(.init(
-                username: username.isEmpty ? "이름없음" : username,
+                username: username.isEmpty ? nil : username,
                 avatarUrl: nil,
                 provider: "APPLE",
                 providerId: userIdentifier

--- a/TILApp/Views/CommunityView/FollowListViewController.swift
+++ b/TILApp/Views/CommunityView/FollowListViewController.swift
@@ -185,6 +185,7 @@ extension FollowListViewController: UITableViewDelegate {
     }
 
     func scrollViewDidEndDragging(_: UIScrollView, willDecelerate _: Bool) {
+        guard let refreshControl = tableView.refreshControl, refreshControl.isRefreshing else { return }
         Task {
             _ = await loadFollowList()
             tableView.reloadData()

--- a/TILApp/Views/CommunityView/UserProfileViewController.swift
+++ b/TILApp/Views/CommunityView/UserProfileViewController.swift
@@ -403,6 +403,7 @@ extension UserProfileViewController: UITableViewDelegate {
     func tableView(_: UITableView, didSelectRowAt _: IndexPath) {}
 
     func scrollViewDidEndDragging(_: UIScrollView, willDecelerate _: Bool) {
+        guard let refreshControl = userProfileTableView.refreshControl, refreshControl.isRefreshing else { return }
         loadPosts { [weak self] in
             self?.userProfileTableView.reloadData()
             self?.userProfileTableView.refreshControl?.endRefreshing()

--- a/TILApp/Views/MyProfileViewController/MyProfileViewController.swift
+++ b/TILApp/Views/MyProfileViewController/MyProfileViewController.swift
@@ -118,7 +118,6 @@ final class MyProfileViewController: UIViewController {
 
         loadMyPosts { [weak self] in
             self?.myProfileTableView.reloadData()
-            self?.myProfileTableView.setNeedsLayout()
         }
 
         screenView.flex.direction(.column).define { flex in
@@ -347,7 +346,8 @@ extension MyProfileViewController: SeeMoreBottomSheetDelegate {
             }
         } else if title == "로그아웃" {
             let alertController = UIAlertController(title: "로그아웃", message: "정말 로그아웃하시겠어요?", preferredStyle: .alert)
-            alertController.addAction(.init(title: "계속", style: .destructive, handler: { _ in
+            alertController.addAction(.init(title: "계속", style: .destructive, handler: { [weak self] _ in
+                self?.dismiss(animated: true)
                 AuthViewModel.shared.signOut()
             }))
             alertController.addAction(.init(title: "취소", style: .cancel))

--- a/TILApp/Views/MyProfileViewController/MyProfileViewController.swift
+++ b/TILApp/Views/MyProfileViewController/MyProfileViewController.swift
@@ -153,8 +153,9 @@ final class MyProfileViewController: UIViewController {
 
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
-        screenView.pin.all(view.pin.safeArea)
-        moreButton.pin.top(view.pin.safeArea).right(25).marginTop(5)
+        let safeArea = view.pin.safeArea
+        screenView.pin.all(safeArea)
+        moreButton.pin.top(safeArea).right(safeArea.right + 25).marginTop(5)
         screenView.flex.layout()
     }
 
@@ -299,6 +300,7 @@ extension MyProfileViewController: UITableViewDelegate {
     }
 
     func scrollViewDidEndDragging(_: UIScrollView, willDecelerate _: Bool) {
+        guard let refreshControl = myProfileTableView.refreshControl, refreshControl.isRefreshing else { return }
         loadMyPosts { [weak self] in
             self?.myProfileTableView.reloadData()
             self?.myProfileTableView.refreshControl?.endRefreshing()

--- a/TILApp/Views/MyProfileViewController/ProfileEditViewController.swift
+++ b/TILApp/Views/MyProfileViewController/ProfileEditViewController.swift
@@ -120,7 +120,8 @@ final class ProfileEditViewController: UIViewController {
             message: "정말로 회원 탈퇴를 하시겠어요?\n회원 탈퇴 시 저장한 블로그와 게시글이 모두 삭제되어 복구할 수 없습니다.",
             preferredStyle: .alert
         )
-        alertController.addAction(.init(title: "탈퇴", style: .destructive) { _ in
+        alertController.addAction(.init(title: "탈퇴", style: .destructive) { [weak self] _ in
+            self?.navigationController?.popViewController(animated: true)
             AuthViewModel.shared.withdraw()
         })
         alertController.addAction(.init(title: "취소", style: .cancel, handler: nil))

--- a/TILApp/Views/Shared/RootViewController.swift
+++ b/TILApp/Views/Shared/RootViewController.swift
@@ -25,9 +25,7 @@ final class RootViewController: UINavigationController {
                     title: tab.title,
                     image: .init(systemName: tab.icon),
                     tag: index
-                ).then {
-                    $0.imageInsets = .init(top: 5, left: 0, bottom: 5, right: 0)
-                }
+                )
                 return tab.controller
             }, animated: false)
         }

--- a/TILApp/Views/Shared/RootViewController.swift
+++ b/TILApp/Views/Shared/RootViewController.swift
@@ -1,11 +1,13 @@
 import UIKit
 
-final class RootViewController: UITabBarController {
-    struct Tab {
+final class RootViewController: UINavigationController {
+    private struct Tab {
         let title: String
         let icon: String
         let controller: UIViewController
     }
+
+    private(set) var _tabBarController: UITabBarController?
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -17,29 +19,21 @@ final class RootViewController: UITabBarController {
             .init(title: "내 정보", icon: "person", controller: MyProfileViewController()),
         ]
 
-        setViewControllers(tabs.enumerated().map { index, tab in
-            let navigationController = UINavigationController(rootViewController: tab.controller)
-            let tabBarItem = UITabBarItem(
-                title: tab.title,
-                image: .init(systemName: tab.icon),
-                tag: index
-            )
-            navigationController.tabBarItem = tabBarItem
-            return navigationController
-        }, animated: false)
+        let tabBarController = UITabBarController().then {
+            $0.setViewControllers(tabs.enumerated().map { index, tab in
+                tab.controller.tabBarItem = .init(
+                    title: tab.title,
+                    image: .init(systemName: tab.icon),
+                    tag: index
+                ).then {
+                    $0.imageInsets = .init(top: 5, left: 0, bottom: 5, right: 0)
+                }
+                return tab.controller
+            }, animated: false)
+        }
 
+        setViewControllers([tabBarController], animated: true)
+        _tabBarController = tabBarController
         RssViewModel.shared.prepare()
-    }
-
-    override func viewDidLayoutSubviews() {
-        super.viewDidLayoutSubviews()
-
-        let paddingTop: CGFloat = 10.0
-        tabBar.frame = .init(
-            x: tabBar.frame.origin.x,
-            y: tabBar.frame.origin.y - paddingTop,
-            width: tabBar.frame.width,
-            height: tabBar.frame.height + paddingTop
-        )
     }
 }

--- a/TILApp/Views/Shared/RootViewController.swift
+++ b/TILApp/Views/Shared/RootViewController.swift
@@ -11,7 +11,7 @@ final class RootViewController: UITabBarController {
         super.viewDidLoad()
 
         let tabs: [Tab] = [
-//            .init(title: "홈", icon: "house", controller: HomeViewController()),
+            //            .init(title: "홈", icon: "house", controller: HomeViewController()),
             .init(title: "홈", icon: "house", controller: CalendarViewController()),
             .init(title: "커뮤니티", icon: "bubble.left", controller: CommunityViewController()),
             .init(title: "내 정보", icon: "person", controller: MyProfileViewController()),

--- a/TILApp/Views/Test/TestComponentsViewController.swift
+++ b/TILApp/Views/Test/TestComponentsViewController.swift
@@ -5,11 +5,6 @@
 //  Created by 이재희 on 10/27/23.
 //
 
-import FlexLayout
-import PinLayout
-import Then
-import UIKit
-
 //class CustomComponentsViewController: UIViewController {
 //    private lazy var customLargeButton = CustomLargeButton().then {
 //        $0.setTitle("하이하이", for: .normal)


### PR DESCRIPTION
## 작업한 내용 설명

- Navigation 전략을 변경했습니다. TabBar당 하나의 네비게이션이 아닌 네비게이션이 최상단에 위치하도록 개선
- 이를 통해 탭 바가 화면 이동 중에 이상하게 표시되는 문제가 수정되었습니다.
- 테이블 뷰가 탭 바를 벗어나는 문제를 해결했습니다.
- 로그인 화면이 이제 따로 띄워지는 것이 아닌 RootViewController 위에 위치하게 됩니다.
- 탈퇴한 사용자가 재가입 시 `user-{userId}` 형식으로 생성됩니다.
- 테이블 뷰를 새로고침할 때만 목록 정보를 요청하도록 수정했습니다.

---

resolve #188
resolve #187
